### PR TITLE
Sort geolock blacklisted countries alphabetically

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  bufferutil: true
+  utf-8-validate: true

--- a/src/commands/geolocks.ts
+++ b/src/commands/geolocks.ts
@@ -75,7 +75,9 @@ export class GeolockCommand extends BaseCommand {
           ? [
             {
               name: 'Countries Blacklisted',
-              value: (data.countriesBlacklist ?? []).join(', '),
+              value: [...(data.countriesBlacklist ?? [])]
+                .sort((a, b) => a.localeCompare(b))
+                .join(', '),
             },
           ]
           : []),


### PR DESCRIPTION
## Summary
- Sort the `/geolock` blacklisted country list before rendering it in the embed
- Keep the output stable and easier to scan regardless of API ordering
- Add the workspace config needed for native dependency builds

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Geolock offer response embeds now display the "Countries Blacklisted" field in alphabetical order, ensuring consistent presentation of geolocation restrictions.

* **Chores**
  * Updated build configuration to support additional internal packages and improve build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->